### PR TITLE
fix: clicking on update redirects to read page

### DIFF
--- a/frontend/src/modules/ErpPanelModule/UpdateItem.jsx
+++ b/frontend/src/modules/ErpPanelModule/UpdateItem.jsx
@@ -16,12 +16,10 @@ import { CloseCircleOutlined, PlusOutlined } from '@ant-design/icons';
 import { useHistory } from 'react-router-dom';
 import { StatusTag } from '@/components/Tag';
 
-function SaveForm({ form, config, id }) {
-  let { UPDATE_ENTITY, entity } = config;
-  const history = useHistory();
+function SaveForm({ form, config }) {
+  let { UPDATE_ENTITY } = config;
   const handelClick = () => {
     form.submit();
-    history.push(`/${entity.toLowerCase()}/read/${id}`);
   };
 
   return (
@@ -75,6 +73,7 @@ export default function UpdateItem({ config, UpdateForm }) {
 
     const id = current._id;
     dispatch(erp.update({ entity, id, jsonData: fieldsValue }));
+    history.push(`/${entity.toLowerCase()}/read/${id}`);
   };
   useEffect(() => {
     if (isSuccess) {
@@ -123,7 +122,7 @@ export default function UpdateItem({ config, UpdateForm }) {
           >
             Cancel
           </Button>,
-          <SaveForm config={config} form={form} key={`${uniqueId()}`} id={current?._id} />,
+          <SaveForm config={config} form={form} key={`${uniqueId()}`} />,
         ]}
         style={{
           padding: '20px 0px',

--- a/frontend/src/modules/ErpPanelModule/UpdateItem.jsx
+++ b/frontend/src/modules/ErpPanelModule/UpdateItem.jsx
@@ -38,6 +38,7 @@ export default function UpdateItem({ config, UpdateForm }) {
   const { current, isLoading, isSuccess } = useSelector(selectUpdatedItem);
   const [form] = Form.useForm();
   const [subTotal, setSubTotal] = useState(0);
+  const [id, setId] = useState(current?._id);
 
   const handelValuesChange = (changedValues, values) => {
     const items = values['items'];
@@ -71,15 +72,14 @@ export default function UpdateItem({ config, UpdateForm }) {
       }
     }
 
-    const id = current._id;
     dispatch(erp.update({ entity, id, jsonData: fieldsValue }));
-    history.push(`/${entity.toLowerCase()}/read/${id}`);
   };
   useEffect(() => {
     if (isSuccess) {
       form.resetFields();
       setSubTotal(0);
       dispatch(erp.resetAction({ actionType: 'update' }));
+      history.push(`/${entity.toLowerCase()}/read/${id}`);
       dispatch(erp.list({ entity }));
     }
   }, [isSuccess]);

--- a/frontend/src/modules/ErpPanelModule/UpdateItem.jsx
+++ b/frontend/src/modules/ErpPanelModule/UpdateItem.jsx
@@ -16,10 +16,12 @@ import { CloseCircleOutlined, PlusOutlined } from '@ant-design/icons';
 import { useHistory } from 'react-router-dom';
 import { StatusTag } from '@/components/Tag';
 
-function SaveForm({ form, config }) {
-  let { UPDATE_ENTITY } = config;
+function SaveForm({ form, config, id }) {
+  let { UPDATE_ENTITY, entity } = config;
+  const history = useHistory();
   const handelClick = () => {
     form.submit();
+    history.push(`/${entity.toLowerCase()}/read/${id}`);
   };
 
   return (
@@ -79,7 +81,6 @@ export default function UpdateItem({ config, UpdateForm }) {
       form.resetFields();
       setSubTotal(0);
       dispatch(erp.resetAction({ actionType: 'update' }));
-      updatePanel.close();
       dispatch(erp.list({ entity }));
     }
   }, [isSuccess]);
@@ -122,7 +123,7 @@ export default function UpdateItem({ config, UpdateForm }) {
           >
             Cancel
           </Button>,
-          <SaveForm config={config} form={form} key={`${uniqueId()}`} />,
+          <SaveForm config={config} form={form} key={`${uniqueId()}`} id={current?._id} />,
         ]}
         style={{
           padding: '20px 0px',

--- a/frontend/src/modules/ErpPanelModule/UpdateItem.jsx
+++ b/frontend/src/modules/ErpPanelModule/UpdateItem.jsx
@@ -13,7 +13,7 @@ import { selectUpdatedItem } from '@/redux/erp/selectors';
 import Loading from '@/components/Loading';
 
 import { CloseCircleOutlined, PlusOutlined } from '@ant-design/icons';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useParams } from 'react-router-dom';
 import { StatusTag } from '@/components/Tag';
 
 function SaveForm({ form, config }) {
@@ -38,7 +38,7 @@ export default function UpdateItem({ config, UpdateForm }) {
   const { current, isLoading, isSuccess } = useSelector(selectUpdatedItem);
   const [form] = Form.useForm();
   const [subTotal, setSubTotal] = useState(0);
-  const [id, setId] = useState(current?._id);
+  const { id } = useParams();
 
   const handelValuesChange = (changedValues, values) => {
     const items = values['items'];


### PR DESCRIPTION
## Description

after clicking on update in erp module the update page stays open 
now it should redirects to entity/read/id

## Related Issues
no issue


