### PR TITLE
fix:Backend we can't remove client if they have at least one invoice or one quote #515

### DIFF
--- a/controllers/erpControllers/clientController.js
+++ b/controllers/erpControllers/clientController.js
@@ -3,10 +3,64 @@ const moment = require('moment');
 
 const Model = mongoose.model('Client');
 const QuoteModel = mongoose.model('Quote');
+const InvoiceModel = mongoose.model('Invoice');
 
 const createCRUDController = require('@/controllers/middlewaresControllers/createCRUDController');
 const methods = createCRUDController('Client');
 
+methods.delete = async (req, res) => {
+  // cannot delete client it it have one invoice or quotes:
+  // check if client have invoice or quotes:
+  const { id } = req.params;
+  try {
+    // first find if there alt least one quote or invoice exist corresponding to the client
+    const quotes = await QuoteModel.findOne({ client: id, removed: false }).exec();
+    if (quotes) {
+      return res.status(400).json({
+        success: false,
+        result: null,
+        message: 'Cannot delete client if client have any quote  or invoice',
+      });
+    }
+    const invoice = await InvoiceModel.findOne({ client: id, removed: false }).exec();
+    if (invoice) {
+      return res.status(400).json({
+        success: false,
+        result: null,
+        message: 'Cannot delete client if client have any quote or invoice',
+      });
+    }
+
+    // if no invoice or quote, delete the client
+    const result = await Model.findOneAndUpdate(
+      { _id: id, removed: false },
+      {
+        $set: {
+          removed: true,
+        },
+      }
+    ).exec();
+    if(!result) {
+      return res.status(404).json({
+        success: false,
+        result: null,
+        message: 'No client found by this id: ' + id,
+      });
+    }
+    return res.status(200).json({
+      success: true,
+      result,
+      message: 'Successfully Deleted the client by id: ' + id,
+    });
+  } catch (err) {
+    return res.status(500).json({
+      success: false,
+      result: null,
+      message: 'Oops there is an Error',
+      error: err,
+    });
+  }
+};
 methods.summary = async (req, res) => {
   try {
     let defaultType = 'month';


### PR DESCRIPTION
## Description

Added delete method in clientController.js which deletes the client if there is no quote or invoice corresponding to that client 
Return error message if there is any  quote or invoice

## Related Issue

Bug : Backend we can't remove client if they have at least one invoice or one quote #515

## Steps to Test

Create a client now add invoice or quote corresponding to that client you have created
Now try to delete this client you won't we able to delete and it shows message there invoice or quote corresponding to this client
Now delete the quote and invoice corresponding to that client and now you will be able to delete the client  

## Video
[video link](https://youtu.be/n6Pgyi9bmQ8)

## Checklist

- [ ] Imported Invoice model in clientController 
- [ ] Added delete method

