### PR TITLE
Feat : Add redirect button to SelectAsync Comp if options is empty

### DIFF
--- a/frontend/src/components/SelectAsync/index.jsx
+++ b/frontend/src/components/SelectAsync/index.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { request } from '@/request';
 import useFetch from '@/hooks/useFetch';
 import { Select } from 'antd';
+import { useHistory } from 'react-router-dom/cjs/react-router-dom.min';
 
 export default function SelectAsync({
   entity,
@@ -13,6 +14,8 @@ export default function SelectAsync({
   const [isLoading, setIsLoading] = useState(false);
   const [selectOptions, setOptions] = useState([]);
   const [currentValue, setCurrentValue] = useState(undefined);
+
+  const history = useHistory();
 
   const asyncList = () => {
     return request.list({ entity });
@@ -34,18 +37,30 @@ export default function SelectAsync({
     }
   }, [value]);
 
+  const handleSelectChange = (newValue) => {
+    if (newValue === 'addPayment') {
+      // Navigate to another page when "Add payment" is selected
+      history.push('/payment/mode');
+    } else {
+      // Handle other select options
+      if (onChange) {
+        onChange(newValue[outputValue] || newValue);
+      }
+    }
+  };
+
   return (
     <Select
       loading={isLoading}
       disabled={isLoading}
       value={currentValue}
-      onChange={(newValue) => {
-        // setCurrentValue(newValue[outputValue] || newValue);
-        if (onChange) {
-          onChange(newValue[outputValue] || newValue);
-        }
-      }}
+      onChange={handleSelectChange}
     >
+      {selectOptions.length === 0 && (
+        <Select.Option key="addPayment" value="addPayment">
+          Add payment
+        </Select.Option>
+      )}
       {selectOptions.map((optionField) => (
         <Select.Option
           key={optionField[outputValue] || optionField}

--- a/frontend/src/components/SelectAsync/index.jsx
+++ b/frontend/src/components/SelectAsync/index.jsx
@@ -10,6 +10,9 @@ export default function SelectAsync({
   outputValue = '_id',
   value,
   onChange,
+  labelText = '',
+  withRedirect = false,
+  urlToRedirect = '/',
 }) {
   const [isLoading, setIsLoading] = useState(false);
   const [selectOptions, setOptions] = useState([]);
@@ -38,9 +41,9 @@ export default function SelectAsync({
   }, [value]);
 
   const handleSelectChange = (newValue) => {
-    if (newValue === 'addPayment') {
+    if (newValue === 'redirectURL') {
       // Navigate to another page when "Add payment" is selected
-      history.push('/payment/mode');
+      history.push(urlToRedirect);
     } else {
       // Handle other select options
       if (onChange) {
@@ -56,9 +59,9 @@ export default function SelectAsync({
       value={currentValue}
       onChange={handleSelectChange}
     >
-      {selectOptions.length === 0 && (
-        <Select.Option key="addPayment" value="addPayment">
-          Add payment
+      {selectOptions.length === 0 && withRedirect && (
+        <Select.Option key="redirectURL" value="redirectURL">
+          {labelText}
         </Select.Option>
       )}
       {selectOptions.map((optionField) => (

--- a/frontend/src/components/SelectAsync/index.jsx
+++ b/frontend/src/components/SelectAsync/index.jsx
@@ -3,6 +3,7 @@ import { request } from '@/request';
 import useFetch from '@/hooks/useFetch';
 import { Select } from 'antd';
 import { useHistory } from 'react-router-dom/cjs/react-router-dom.min';
+import { PlusCircleOutlined } from '@ant-design/icons';
 
 export default function SelectAsync({
   entity,
@@ -10,7 +11,7 @@ export default function SelectAsync({
   outputValue = '_id',
   value,
   onChange,
-  labelText = '',
+  redirectLabel = '',
   withRedirect = false,
   urlToRedirect = '/',
 }) {
@@ -61,7 +62,7 @@ export default function SelectAsync({
     >
       {selectOptions.length === 0 && withRedirect && (
         <Select.Option key="redirectURL" value="redirectURL">
-          {labelText}
+          <PlusCircleOutlined /> {redirectLabel}
         </Select.Option>
       )}
       {selectOptions.map((optionField) => (

--- a/frontend/src/forms/PaymentInvoiceForm.jsx
+++ b/frontend/src/forms/PaymentInvoiceForm.jsx
@@ -65,7 +65,7 @@ export default function PaymentInvoiceForm({ maxAmount = null, isUpdateForm = fa
           },
         ]}
       >
-        <SelectAsync entity={'paymentMode'} displayLabels={['name']}></SelectAsync>
+        <SelectAsync entity={'paymentMode'} displayLabels={['name']} withRedirect={true} urlToRedirect='/payment/mode' labelText='Add Payment Mode'></SelectAsync>
       </Form.Item>
       <Form.Item label="Reference" name="ref">
         <Input />

--- a/frontend/src/forms/PaymentInvoiceForm.jsx
+++ b/frontend/src/forms/PaymentInvoiceForm.jsx
@@ -65,7 +65,7 @@ export default function PaymentInvoiceForm({ maxAmount = null, isUpdateForm = fa
           },
         ]}
       >
-        <SelectAsync entity={'paymentMode'} displayLabels={['name']} withRedirect={true} urlToRedirect='/payment/mode' labelText='Add Payment Mode'></SelectAsync>
+        <SelectAsync entity={'paymentMode'} displayLabels={['name']} withRedirect={true} urlToRedirect='/payment/mode' redirectLabel='Add Payment Mode'></SelectAsync>
       </Form.Item>
       <Form.Item label="Reference" name="ref">
         <Input />


### PR DESCRIPTION
## Description

If list is empty 
       it will show add Payment . On clicking it user will be redirected to add payment mode page. 
else 
       it will show only payment modes. on clicking that modes , user can select them
## Related Issues

#496 


## Checklist

- [x] I have tested these changes
- [ ] I have updated the relevant documentation
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the codebase
- [x] My changes generate no new warnings or errors
- [x] The title of my pull request is clear and descriptive
