### PR TITLE
constraint added on tax feild

### DIFF
--- a/frontend/src/pages/Settings/PaymentSettings.jsx
+++ b/frontend/src/pages/Settings/PaymentSettings.jsx
@@ -29,7 +29,7 @@ export default function PaymentSettings() {
             <SelectCurrency />
           </Form.Item>
           <Form.Item label="Tax">
-            <InputNumber addonBefore={'%'} placeholder="0" />
+            <InputNumber min={0} addonBefore={'%'} placeholder="0" />
           </Form.Item>
         </SetingsSection>
 


### PR DESCRIPTION
## Description

Tax feild can be setting negative which is not possible I have add a constraint min should be 0.


## Steps to Test
1. Go to /settings
2. Click on the payment settings
3. Then on the tax field.

## Screenshots (if applicable)

### Before
<img width="1119" alt="image" src="https://github.com/idurar/erp-crm/assets/96794196/16256a22-d9db-4238-b832-a6f690c392e5">

### After
<img width="1168" alt="image" src="https://github.com/idurar/erp-crm/assets/96794196/12eff5d2-0c3b-4296-af5d-653b62921faa">


## Checklist

- [X] I have tested these changes
- [X] I have updated the relevant documentation
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the codebase
- [X] My changes generate no new warnings or errors
- [X] The title of my pull request is clear and descriptive
