### PR TITLE
Feature/#548 new email editor page

### DIFF
--- a/controllers/coreControllers/emailController/index.js
+++ b/controllers/coreControllers/emailController/index.js
@@ -1,0 +1,14 @@
+const createCRUDController = require('@/controllers/middlewaresControllers/createCRUDController');
+const crudController = createCRUDController('Email');
+
+const emailMethods = {
+  create:crudController.create,
+  read: crudController.read,
+  update: crudController.update,
+  list: crudController.list,
+  listAll: crudController.listAll,
+  filter: crudController.filter,
+  search: crudController.search,
+};
+
+module.exports = emailMethods;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,6 +25,7 @@
         "react-error-boundary": "3.1.3",
         "react-helmet": "6.1.0",
         "react-portal": "4.2.1",
+        "react-quill": "^2.0.0",
         "react-redux": "7.2.8",
         "react-router-dom": "5.2.0",
         "react-scripts": "4.0.3",
@@ -3991,6 +3992,14 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.5.tgz",
       "integrity": "sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ=="
+    },
+    "node_modules/@types/quill": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@types/quill/-/quill-1.3.10.tgz",
+      "integrity": "sha512-IhW3fPW+bkt9MLNlycw8u8fWb7oO7W5URC9MfZYHBlA24rex9rs23D5DETChu1zvgVdc5ka64ICjJOgQMr6Shw==",
+      "dependencies": {
+        "parchment": "^1.1.2"
+      }
     },
     "node_modules/@types/react": {
       "version": "18.2.21",
@@ -9473,6 +9482,11 @@
       "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
       "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
     "node_modules/extend-shallow": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
@@ -9537,6 +9551,11 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
     },
     "node_modules/fast-glob": {
       "version": "3.3.1",
@@ -15512,6 +15531,11 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/parchment": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
+      "integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg=="
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -17359,6 +17383,69 @@
         }
       ]
     },
+    "node_modules/quill": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
+      "integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
+      "dependencies": {
+        "clone": "^2.1.1",
+        "deep-equal": "^1.0.1",
+        "eventemitter3": "^2.0.3",
+        "extend": "^3.0.2",
+        "parchment": "^1.1.4",
+        "quill-delta": "^3.6.2"
+      }
+    },
+    "node_modules/quill-delta": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
+      "integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
+      "dependencies": {
+        "deep-equal": "^1.0.1",
+        "extend": "^3.0.2",
+        "fast-diff": "1.1.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/quill-delta/node_modules/deep-equal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "dependencies": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/quill/node_modules/deep-equal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "dependencies": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/quill/node_modules/eventemitter3": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
+      "integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg=="
+    },
     "node_modules/raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
@@ -18338,6 +18425,20 @@
       },
       "peerDependencies": {
         "react": "^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0"
+      }
+    },
+    "node_modules/react-quill": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-quill/-/react-quill-2.0.0.tgz",
+      "integrity": "sha512-4qQtv1FtCfLgoD3PXAur5RyxuUbPXQGOHgTlFie3jtxp43mXDtzCKaOgQ3mLyZfi1PUlyjycfivKelFhy13QUg==",
+      "dependencies": {
+        "@types/quill": "^1.3.10",
+        "lodash": "^4.17.4",
+        "quill": "^1.3.7"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18",
+        "react-dom": "^16 || ^17 || ^18"
       }
     },
     "node_modules/react-redux": {
@@ -27079,6 +27180,14 @@
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.5.tgz",
       "integrity": "sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ=="
     },
+    "@types/quill": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@types/quill/-/quill-1.3.10.tgz",
+      "integrity": "sha512-IhW3fPW+bkt9MLNlycw8u8fWb7oO7W5URC9MfZYHBlA24rex9rs23D5DETChu1zvgVdc5ka64ICjJOgQMr6Shw==",
+      "requires": {
+        "parchment": "^1.1.2"
+      }
+    },
     "@types/react": {
       "version": "18.2.21",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.21.tgz",
@@ -31329,6 +31438,11 @@
         }
       }
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
     "extend-shallow": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
@@ -31380,6 +31494,11 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
     },
     "fast-glob": {
       "version": "3.3.1",
@@ -36057,6 +36176,11 @@
         "tslib": "^2.0.3"
       }
     },
+    "parchment": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
+      "integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg=="
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -37536,6 +37660,64 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
+    "quill": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
+      "integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
+      "requires": {
+        "clone": "^2.1.1",
+        "deep-equal": "^1.0.1",
+        "eventemitter3": "^2.0.3",
+        "extend": "^3.0.2",
+        "parchment": "^1.1.4",
+        "quill-delta": "^3.6.2"
+      },
+      "dependencies": {
+        "deep-equal": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+          "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+          "requires": {
+            "is-arguments": "^1.0.4",
+            "is-date-object": "^1.0.1",
+            "is-regex": "^1.0.4",
+            "object-is": "^1.0.1",
+            "object-keys": "^1.1.1",
+            "regexp.prototype.flags": "^1.2.0"
+          }
+        },
+        "eventemitter3": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
+          "integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg=="
+        }
+      }
+    },
+    "quill-delta": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
+      "integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
+      "requires": {
+        "deep-equal": "^1.0.1",
+        "extend": "^3.0.2",
+        "fast-diff": "1.1.2"
+      },
+      "dependencies": {
+        "deep-equal": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+          "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+          "requires": {
+            "is-arguments": "^1.0.4",
+            "is-date-object": "^1.0.1",
+            "is-regex": "^1.0.4",
+            "object-is": "^1.0.1",
+            "object-keys": "^1.1.1",
+            "regexp.prototype.flags": "^1.2.0"
+          }
+        }
+      }
+    },
     "raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
@@ -38255,6 +38437,16 @@
       "integrity": "sha512-fE9kOBagwmTXZ3YGRYb4gcMy+kSA+yLO0xnPankjRlfBv4uCpFXqKPfkpsGQQR15wkZ9EssnvTOl1yMzbkxhPQ==",
       "requires": {
         "prop-types": "^15.5.8"
+      }
+    },
+    "react-quill": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-quill/-/react-quill-2.0.0.tgz",
+      "integrity": "sha512-4qQtv1FtCfLgoD3PXAur5RyxuUbPXQGOHgTlFie3jtxp43mXDtzCKaOgQ3mLyZfi1PUlyjycfivKelFhy13QUg==",
+      "requires": {
+        "@types/quill": "^1.3.10",
+        "lodash": "^4.17.4",
+        "quill": "^1.3.7"
       }
     },
     "react-redux": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,8 +6,12 @@
   },
   "dependencies": {
     "@ant-design/icons": "4.7.0",
+    "@craco/craco": "5.5.0",
     "antd": "4.17.4",
     "axios": "0.27.2",
+    "craco-alias": "3.0.1",
+    "craco-less": "1.17.1",
+    "cross-env": "7.0.3",
     "currency.js": "2.0.4",
     "dayjs": "1.10.4",
     "framer-motion": "4.1.13",
@@ -18,6 +22,7 @@
     "react-error-boundary": "3.1.3",
     "react-helmet": "6.1.0",
     "react-portal": "4.2.1",
+    "react-quill": "^2.0.0",
     "react-redux": "7.2.8",
     "react-router-dom": "5.2.0",
     "react-scripts": "4.0.3",
@@ -26,11 +31,7 @@
     "redux-logger": "3.0.6",
     "redux-thunk": "2.4.1",
     "reselect": "4.1.5",
-    "web-vitals": "1.0.1",
-    "@craco/craco": "5.5.0",
-    "craco-alias": "3.0.1",
-    "craco-less": "1.17.1",
-    "cross-env": "7.0.3"
+    "web-vitals": "1.0.1"
   },
   "scripts": {
     "start": "craco start",

--- a/frontend/src/app/Navigation/index.jsx
+++ b/frontend/src/app/Navigation/index.jsx
@@ -33,6 +33,7 @@ const SIDEBAR_MENU = [
 
 const SETTINGS_SUBMENU = [
   { key: '/settings', title: 'General Settings' },
+   { key: '/email', title: 'Email templates' },
   { key: '/payment/mode', title: 'Payment Mode' },
   { key: '/settings/advanced', title: 'Advanced Settings' },
 ];

--- a/frontend/src/modules/EmailModule/EmailDataTableModule/components/DataTableDropMenu.jsx
+++ b/frontend/src/modules/EmailModule/EmailDataTableModule/components/DataTableDropMenu.jsx
@@ -1,0 +1,46 @@
+import { Menu } from 'antd';
+
+import {
+  EyeOutlined,
+  EditOutlined,
+  DeleteOutlined,
+  FilePdfOutlined,
+  CreditCardOutlined,
+} from '@ant-design/icons';
+import { useSelector, useDispatch } from 'react-redux';
+import { erp } from '@/redux/erp/actions';
+import { selectItemById } from '@/redux/erp/selectors';
+import { useErpContext } from '@/context/erp';
+
+import { DOWNLOAD_BASE_URL } from '@/config/serverApiConfig';
+import uniqueId from '@/utils/uinqueId';
+import { useHistory } from 'react-router-dom';
+
+export default function DataTableDropMenu({ row, entity }) {
+  const dispatch = useDispatch();
+  const history = useHistory();
+  const { erpContextAction } = useErpContext();
+  const { recordPanel, modal } = erpContextAction;
+  const item = useSelector(selectItemById(row._id));
+  function Read() {
+    dispatch(erp.currentItem({ data: item }));
+    // readPanel.open();
+    history.push(`/email/read/${row._id}`);
+  }
+
+  function Edit() {
+    dispatch(erp.currentAction({ actionType: 'update', data: item }));
+    // updatePanel.open();
+    history.push(`/email/update/${row._id}`);
+  }
+  return (
+    <Menu style={{ minWidth: 130 }}>
+      <Menu.Item key={`${uniqueId()}`} icon={<EyeOutlined />} onClick={Read}>
+        Show
+      </Menu.Item>
+      <Menu.Item key={`${uniqueId()}`} icon={<EditOutlined />} onClick={Edit}>
+        Edit
+      </Menu.Item>
+    </Menu>
+  );
+}

--- a/frontend/src/modules/EmailModule/EmailDataTableModule/index.jsx
+++ b/frontend/src/modules/EmailModule/EmailDataTableModule/index.jsx
@@ -1,0 +1,11 @@
+import { ErpLayout } from '@/layout';
+import ErpPanel from '@/modules/ErpPanelModule';
+import DataTableDropMenu from './components/DataTableDropMenu';
+
+export default function EmailDataTableModule({ config }) {
+  return (
+    <ErpLayout>
+      <ErpPanel config={config} DataTableDropMenu={DataTableDropMenu}></ErpPanel>
+    </ErpLayout>
+  );
+}

--- a/frontend/src/modules/EmailModule/ReadEmailModule/components/ReadItem.jsx
+++ b/frontend/src/modules/EmailModule/ReadEmailModule/components/ReadItem.jsx
@@ -1,0 +1,103 @@
+import React, { useState, useEffect } from 'react';
+import { Divider,Typography , Button, PageHeader} from 'antd';
+import {
+  EditOutlined,
+  CloseCircleOutlined,
+} from '@ant-design/icons';
+
+import { useSelector, useDispatch } from 'react-redux';
+import { erp } from '@/redux/erp/actions';
+
+import { useErpContext } from '@/context/erp';
+import uniqueId from '@/utils/uinqueId';
+
+import { selectCurrentItem } from '@/redux/erp/selectors';
+
+import { useHistory } from 'react-router-dom/cjs/react-router-dom.min';
+
+const {Title,Paragraph} = Typography;
+
+export default function ReadItem({ config, selectedItem }) {
+  const { entity, ENTITY_NAME } = config;
+  const dispatch = useDispatch();
+  const { erpContextAction } = useErpContext();
+  const history = useHistory();
+
+  const { result: currentResult } = useSelector(selectCurrentItem);
+
+  const { readPanel, updatePanel } = erpContextAction;
+
+  const resetErp = {
+    emailName:'',
+    emailKey:'',
+    emailSubject:'',
+    emailBody:'',
+    emailVariables:[],
+    _id:'',
+  };
+
+  const [currentErp, setCurrentErp] = useState(selectedItem ?? resetErp);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    if (currentResult) {
+      setCurrentErp(currentResult);
+    }
+    return () => controller.abort();
+  }, [currentResult]);
+
+  return (
+    <>
+      <PageHeader
+        onBack={() => {
+          readPanel.close();
+          history.goBack();
+        }}
+        title={`${ENTITY_NAME} # ${currentErp?.emailName}`}
+        ghost={false}
+        extra={[
+          <Button
+            key={`${uniqueId()}`}
+            onClick={() => {
+              readPanel.close();
+              history.push(`/${entity.toLowerCase()}`);
+            }}
+            icon={<CloseCircleOutlined />}
+          >
+            Close
+          </Button>,
+
+          <Button
+            key={`${uniqueId()}`}
+            onClick={() => {
+              dispatch(
+                erp.currentAction({
+                  actionType: 'update',
+                  data: currentErp,
+                })
+              );
+              updatePanel.open();
+              history.push(`/${entity.toLowerCase()}/update/${currentErp._id}`);
+            }}
+            type="primary"
+            icon={<EditOutlined />}
+          >
+            Edit Template
+          </Button>,
+        ]}
+        style={{
+          padding: '20px 0px',
+        }}
+      >
+      </PageHeader>
+      <Divider dashed />
+      <div>
+        
+          <Title level={3}>Subject</Title>
+          <Paragraph>{currentErp.emailSubject}</Paragraph>
+          <Title level={3}>Body</Title>
+          <div dangerouslySetInnerHTML={{__html:currentErp.emailBody}}/>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/modules/EmailModule/ReadEmailModule/index.jsx
+++ b/frontend/src/modules/EmailModule/ReadEmailModule/index.jsx
@@ -1,0 +1,53 @@
+import { Button, Result } from 'antd';
+import { ErpLayout } from '@/layout';
+import ReadItem from './components/ReadItem';
+
+import PageLoader from '@/components/PageLoader';
+import { erp } from '@/redux/erp/actions';
+import { selectReadItem } from '@/redux/erp/selectors';
+import { useLayoutEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useParams, useHistory } from 'react-router-dom';
+
+export default function ReadEmailModule({ config }) {
+  const dispatch = useDispatch();
+  const { id } = useParams();
+  const history = useHistory();
+
+  useLayoutEffect(() => {
+    dispatch(erp.read({ entity: config.entity, id }));
+  }, [id]);
+
+  const { result: currentResult, isSuccess, isLoading = true } = useSelector(selectReadItem);
+
+  if (isLoading) {
+    return (
+      <ErpLayout>
+        <PageLoader />
+      </ErpLayout>
+    );
+  } else
+    return (
+      <ErpLayout>
+        {isSuccess ? (
+          <ReadItem config={config} selectedItem={currentResult} />
+        ) : (
+          <Result
+            status="404"
+            title="Quote not found"
+            subTitle="Sorry, the Quote you requested does not exist."
+            extra={
+              <Button
+                type="primary"
+                onClick={() => {
+                  history.push(`/${config.entity.toLowerCase()}`);
+                }}
+              >
+                Back to Quote Page
+              </Button>
+            }
+          />
+        )}
+      </ErpLayout>
+    );
+}

--- a/frontend/src/modules/EmailModule/UpdateEmailModule/componenets/EmailForm.jsx
+++ b/frontend/src/modules/EmailModule/UpdateEmailModule/componenets/EmailForm.jsx
@@ -1,0 +1,44 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { Form, Input, InputNumber, Button, Select, Divider, Row, Col , Typography, Tag } from 'antd';
+import ReactQuill from 'react-quill';
+import 'react-quill/dist/quill.snow.css';
+import { PlusOutlined } from '@ant-design/icons';
+
+
+const {Paragraph} = Typography;
+
+export default function EmailForm({ current = null }) {
+
+  const [body,setBody] = useState(current?.emailBody);
+
+  const displayLabels = (labels=[]) => <>{labels.map(
+    label=><Tag onClick={() => setBody(body)} color='blue' >{label}</Tag>
+  )}</>
+
+  const setBodyValue = (value) => {
+    setBody(value);
+    current.emailBody = value;
+  }
+
+  return (
+    <>
+      <Form.Item label="Available Variables">
+        {displayLabels(current?.emailVariables)}
+      </Form.Item>
+      <Form.Item label="Subject" name="emailSubject">
+        <Input />
+      </Form.Item>
+      <Form.Item label="Body" name="emailBody">
+        <ReactQuill theme="snow" value={body} onChange={setBodyValue}/>
+      </Form.Item>
+      <Paragraph type='success'>To write a variable name use the convention {`{{variable}}`} for e.g. name - {`{{name}}`}</Paragraph>
+      <Col className='gutter-row' span={5}>
+        <Form.Item>
+          <Button type="primary" htmlType="submit" icon={<PlusOutlined />} block>
+            Update Email template
+          </Button>
+      </Form.Item>
+      </Col>
+    </>
+  );
+}

--- a/frontend/src/modules/EmailModule/UpdateEmailModule/index.jsx
+++ b/frontend/src/modules/EmailModule/UpdateEmailModule/index.jsx
@@ -1,0 +1,63 @@
+import { Button, Result } from 'antd';
+
+import { ErpLayout } from '@/layout';
+import UpdateItem from '@/modules/ErpPanelModule/UpdateItem';
+import EmailForm from './componenets/EmailForm';
+
+import PageLoader from '@/components/PageLoader';
+
+import { erp } from '@/redux/erp/actions';
+import { selectReadItem } from '@/redux/erp/selectors';
+import { useLayoutEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useParams, useHistory } from 'react-router-dom';
+
+export default function UpdateEmailModule({ config }) {
+  const dispatch = useDispatch();
+
+  const { id } = useParams();
+  const history = useHistory();
+
+  useLayoutEffect(() => {
+    dispatch(erp.read({ entity: config.entity, id }));
+  }, [id]);
+
+  const { result: currentResult, isSuccess, isLoading = true } = useSelector(selectReadItem);
+
+  useLayoutEffect(() => {
+    if (currentResult) {
+      dispatch(erp.currentAction({ actionType: 'update', data: currentResult }));
+    }
+  }, [currentResult]);
+
+  if (isLoading) {
+    return (
+      <ErpLayout>
+        <PageLoader />
+      </ErpLayout>
+    );
+  } else
+    return (
+      <ErpLayout>
+        {isSuccess ? (
+          <UpdateItem config={config} UpdateForm={EmailForm} />
+        ) : (
+          <Result
+            status="404"
+            title="Quote not found"
+            subTitle="Sorry, the Quote you requested does not exist."
+            extra={
+              <Button
+                type="primary"
+                onClick={() => {
+                  history.push(`/${config.entity.toLowerCase()}`);
+                }}
+              >
+                Back to Quote Page
+              </Button>
+            }
+          />
+        )}
+      </ErpLayout>
+    );
+}

--- a/frontend/src/modules/ErpPanelModule/DataTable.jsx
+++ b/frontend/src/modules/ErpPanelModule/DataTable.jsx
@@ -78,7 +78,7 @@ export default function DataTable({ config, DataTableDropMenu }) {
             <Button onClick={handelDataTableLoad} key={`${uniqueId()}`} icon={<RedoOutlined />}>
               Refresh
             </Button>,
-              create?<AddNewItem config={config} key={`${uniqueId()}`} />:<>y</>,
+              create?<AddNewItem config={config} key={`${uniqueId()}`} />:<></>,
           ]}
           style={{
             padding: '20px 0px',

--- a/frontend/src/modules/ErpPanelModule/DataTable.jsx
+++ b/frontend/src/modules/ErpPanelModule/DataTable.jsx
@@ -29,7 +29,7 @@ function AddNewItem({ config }) {
 }
 
 export default function DataTable({ config, DataTableDropMenu }) {
-  let { entity, dataTableColumns } = config;
+  let { entity, dataTableColumns ,create=true} = config;
   const { DATATABLE_TITLE } = config;
   dataTableColumns = [
     ...dataTableColumns,
@@ -78,7 +78,7 @@ export default function DataTable({ config, DataTableDropMenu }) {
             <Button onClick={handelDataTableLoad} key={`${uniqueId()}`} icon={<RedoOutlined />}>
               Refresh
             </Button>,
-            <AddNewItem config={config} key={`${uniqueId()}`} />,
+              create?<AddNewItem config={config} key={`${uniqueId()}`} />:<>y</>,
           ]}
           style={{
             padding: '20px 0px',

--- a/frontend/src/pages/Email/EmailRead.jsx
+++ b/frontend/src/pages/Email/EmailRead.jsx
@@ -1,0 +1,13 @@
+import configPage from './config';
+import ReadEmailModule from '@/modules/EmailModule/ReadEmailModule';
+
+export default function EmailRead() {
+  const customConfig = {
+    /*your custom config*/
+  };
+  const config = {
+    ...configPage,
+    //customConfig,
+  };
+  return <ReadEmailModule config={config} />;
+}

--- a/frontend/src/pages/Email/EmailUpdate.jsx
+++ b/frontend/src/pages/Email/EmailUpdate.jsx
@@ -1,0 +1,13 @@
+import configPage from './config';
+import UpdateEmailModule from '@/modules/EmailModule/UpdateEmailModule';
+
+export default function EmailUpdate() {
+  const customConfig = {
+    /*your custom config*/
+  };
+  const config = {
+    ...configPage,
+    //customConfig,
+  };
+  return <UpdateEmailModule config={config} />;
+}

--- a/frontend/src/pages/Email/config/index.js
+++ b/frontend/src/pages/Email/config/index.js
@@ -1,0 +1,18 @@
+const entity = 'email';
+
+const Labels = {
+  PANEL_TITLE: 'Email Templates',
+  dataTableTitle: 'Templates Lists',
+  DATATABLE_TITLE: 'Templates List',
+  ENTITY_NAME: 'Email',
+  CREATE_ENTITY: 'Save Email Template',
+  UPDATE_ENTITY: 'Update Email Template',
+  create:false
+};
+
+const configPage = {
+  entity,
+  ...Labels,
+};
+
+export default configPage;

--- a/frontend/src/pages/Email/index.jsx
+++ b/frontend/src/pages/Email/index.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import configPage from './config';
+import CrudModule from '@/modules/CrudModule';
+import AdvancedSettingsForm from '@/forms/AdvancedSettingsForm';
+import EmailDataTableModule from '@/modules/EmailModule/EmailDataTableModule';
+
+export default function AdvancedSettings() {
+  const entity = 'email';
+  const searchConfig = {
+    displayLabels: ['name'],
+    searchFields: 'name',
+    outputValue: '_id',
+  };
+
+  const entityDisplayLabels = ['name'];
+
+  const readColumns = [
+    {
+      title: 'Template Name',
+      dataIndex: 'emailName',
+    },
+    {
+      title: 'Subject',
+      dataIndex: 'emailSubject',
+    },
+    {
+        title:'Body',
+        dataIndex:'emailBody',
+    }
+  ];
+  const dataTableColumns = [
+    {
+      title: 'Template Name',
+      dataIndex: 'emailName',
+    },
+    {
+      title: 'Subject',
+      dataIndex: 'emailSubject',
+      key: 'emailSubject',
+      render: (text, row) => {
+        return {
+          children: (
+            <span>{text}</span>
+          ),
+        };
+      },
+    },
+  ];
+
+
+  const config = {
+    ...configPage,
+    dataTableColumns,
+    searchConfig,
+    entityDisplayLabels
+  };
+  return (
+    <EmailDataTableModule config={config}/>
+  );
+}

--- a/frontend/src/pages/EmailTemplates.jsx
+++ b/frontend/src/pages/EmailTemplates.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { Switch } from 'antd';
+import { CloseOutlined, CheckOutlined } from '@ant-design/icons';
+import CrudModule from '@/modules/CrudModule';
+import AdvancedSettingsForm from '@/forms/AdvancedSettingsForm';
+
+export default function AdvancedSettings() {
+  const entity = 'email';
+  const searchConfig = {
+    displayLabels: ['name'],
+    searchFields: 'name',
+    outputValue: '_id',
+  };
+
+  const entityDisplayLabels = ['name'];
+
+  const readColumns = [
+    {
+      title: 'Template Name',
+      dataIndex: 'emailName',
+    },
+    {
+      title: 'Subject',
+      dataIndex: 'emailSubject',
+    },
+    {
+        title:'Body',
+        dataIndex:'emailBody',
+    }
+  ];
+  const dataTableColumns = [
+    {
+      title: 'Template Name',
+      dataIndex: 'emailName',
+    },
+    {
+      title: 'Subject',
+      dataIndex: 'emailSubject',
+      key: 'emailSubject',
+      render: (text, row) => {
+        return {
+          children: (
+            <span>{text}</span>
+          ),
+        };
+      },
+    },
+  ];
+
+  const ADD_NEW_ENTITY = 'Add new Setting';
+  const DATATABLE_TITLE = 'Email Templates';
+  const ENTITY_NAME = 'template settings';
+  const CREATE_ENTITY = 'Create a setting';
+  const UPDATE_ENTITY = 'Update a Template';
+  const PANEL_TITLE = 'Email Template Panel';
+
+  const config = {
+    entity,
+    PANEL_TITLE,
+    ENTITY_NAME,
+    CREATE_ENTITY,
+    UPDATE_ENTITY,
+    DATATABLE_TITLE,
+    readColumns,
+    dataTableColumns,
+    searchConfig,
+    entityDisplayLabels,
+  };
+  return (
+    <CrudModule
+      createForm={<AdvancedSettingsForm />}
+      updateForm={<AdvancedSettingsForm isUpdateForm={true} />}
+      config={config}
+    />
+  );
+}

--- a/frontend/src/router/RoutesConfig.jsx
+++ b/frontend/src/router/RoutesConfig.jsx
@@ -109,6 +109,18 @@ export const routesConfig = [
     component: 'PaymentMode',
   },
   {
+    path: '/email',
+    component: 'Email/index',
+  },
+  {
+    path: '/email/read/:id',
+    component: 'Email/EmailRead',
+  },
+  {
+    path: '/email/update/:id',
+    component: 'Email/EmailUpdate',
+  },
+  {
     path: '/settings/advanced',
     component: 'AdvancedSettings',
   },

--- a/models/coreModels/Email.js
+++ b/models/coreModels/Email.js
@@ -21,8 +21,28 @@ const emailSchema = new mongoose.Schema({
     required: true,
   },
   emailSubject: {
-    type: mongoose.Schema.Types.Mixed,
+    type: String,
     required: true,
+  },
+  language:{
+    type:String,
+    default:"en"
+  },
+  removed: {
+  type: Boolean,
+  default: false,
+  },
+  enabled: {
+  type: Boolean,
+  default: true,
+  },
+  created: {
+  type: Date,
+  default: Date.now,
+  },
+  updated: {
+  type: Date,
+  default: Date.now,
   },
 });
 

--- a/models/coreModels/Email.js
+++ b/models/coreModels/Email.js
@@ -1,0 +1,29 @@
+const mongoose = require('mongoose');
+mongoose.Promise = global.Promise;
+
+const emailSchema = new mongoose.Schema({
+  emailKey: {
+    type: String,
+    unique: true,
+    lowercase: true,
+    required: true,
+  },
+  emailName: {
+    type: String,
+    unique:true,
+    required:true,
+  },
+  emailVariables:{
+    type:Array
+  },
+  emailBody: {
+    type: String,
+    required: true,
+  },
+  emailSubject: {
+    type: mongoose.Schema.Types.Mixed,
+    required: true,
+  },
+});
+
+module.exports = mongoose.model('Email', emailSchema);

--- a/routes/coreRoutes/coreApi.js
+++ b/routes/coreRoutes/coreApi.js
@@ -8,6 +8,7 @@ const router = express.Router();
 
 const adminController = require('@/controllers/coreControllers/adminController');
 const settingController = require('@/controllers/coreControllers/settingController');
+const emailController = require('@/controllers/coreControllers/emailController');
 
 const {
   createPublicUpload,
@@ -61,6 +62,15 @@ router
   .route('/setting/updateBySettingKey/:settingKey?')
   .patch(catchErrors(settingController.updateBySettingKey));
 router.route('/setting/updateManySetting').patch(catchErrors(settingController.updateManySetting));
+
+// //____________________________________________ API for Email Templates _________________
+router.route('/email/create').post(catchErrors(emailController.create));
+router.route('/email/read/:id').get(catchErrors(emailController.read));
+router.route('/email/update/:id').patch(catchErrors(emailController.update));
+router.route('/email/search').get(catchErrors(emailController.search));
+router.route('/email/list').get(catchErrors(emailController.list));
+router.route('/email/listAll').get(catchErrors(emailController.listAll));
+router.route('/email/filter').get(catchErrors(emailController.filter));
 
 // //____________________________________________ API for Upload controller _________________
 

--- a/setup/config/emailTemplate.json
+++ b/setup/config/emailTemplate.json
@@ -1,44 +1,51 @@
 [
   {
-    "settingKey": "email_invoice_default",
-    "settingValue": "<p>email_invoice_default</p>",
-    "valueType": "string",
-    "isCoreSetting": true
+    "emailKey": "email_invoice_default",
+    "emailName":"Invoice Email",
+    "emailSubject":"Invoice From Idurar",
+    "emailBody": "<p>email_invoice_default</p>",
+    "emailVariables": ["name","time"]
   },
   {
-    "settingKey": "email_quote_default",
-    "settingValue": "<p>email_quote_default</p>",
-    "valueType": "string",
-    "isCoreSetting": true
+    "emailKey": "email_quote_default",
+    "emailName":"Quote Email",
+    "emailSubject":"Quote From Idurar",
+    "emailBody": "<p>email_quote_default</p>",
+    "emailVariables": ["name","time"]
   },
   {
-    "settingKey": "email_offer_default",
-    "settingValue": "<p>email_offer_default</p>",
-    "valueType": "string",
-    "isCoreSetting": true
+    "emailKey": "email_offer_default",
+    "emailName":"Offer Email",
+    "emailSubject":"Invoice From Idurar",
+    "emailBody": "<p>email_offer_default</p>",
+    "emailVariables": []
   },
   {
-    "settingKey": "email_payment_receipt_default",
-    "settingValue": "<p>email_offer_default</p>",
-    "valueType": "string",
-    "isCoreSetting": true
+    "emailKey": "email_payment_receipt_default",
+    "emailName":"Payment Email",
+    "emailSubject":"Payment From Idurar",
+    "emailBody": "<p>email_payment_receipt_default</p>",
+    "emailVariables": ["name","time"]
   },
   {
-    "settingKey": "email_signup_email_confirm_default",
-    "settingValue": "<p>email_signup_email_confirm</p>",
-    "valueType": "string",
-    "isCoreSetting": true
+    "emailKey": "email_signup_email_confirm_default",
+    "emailName":"Signup Confirmation Email",
+    "emailSubject":"Signup Confirmation From Idurar",
+    "emailBody": "<p>email_signup_email_confirm_default</p>",
+    "emailVariables": ["name"]
   },
   {
-    "settingKey": "email_reset_password_default",
-    "settingValue": "<p>email_reset_password</p>",
-    "valueType": "string",
-    "isCoreSetting": true
+    "emailKey": "email_reset_password_default",
+    "emailName":"Password Reset Email",
+    "emailSubject":"Password Reset  From Idurar",
+    "emailBody": "<p>email_reset_password_default</p>",
+    "emailVariables": ["name"]
   },
   {
-    "settingKey": "welcome_email_default",
-    "settingValue": "<p>welcome_email</p>",
-    "valueType": "string",
-    "isCoreSetting": true
+    "emailKey": "welcome_email_default",
+    "emailName":"Welcome Email",
+    "emailSubject":"Welcom From Idurar",
+    "emailBody": "<p>welcome_email</p>",
+    "emailVariables":["name"]
   }
 ]

--- a/setup/setup.js
+++ b/setup/setup.js
@@ -51,7 +51,7 @@ async function setupApp() {
     await Email.insertMany([
       ...emailTemplate
     ])
-    console.log('👍 Email Templates Created : Done!');
+    console.log('👍 Email Templates Created : Done !');
     console.log('🥳 Setup completed :Success!');
     process.exit();
   } catch (e) {

--- a/setup/setup.js
+++ b/setup/setup.js
@@ -29,9 +29,6 @@ async function setupApp() {
     const financeConfig = JSON.parse(
       fs.readFileSync(__dirname + '/config/financeConfig.json', 'utf-8')
     );
-    const emailTemplate = JSON.parse(
-      fs.readFileSync(__dirname + '/config/emailTemplate.json', 'utf-8')
-    );
     const crmConfig = JSON.parse(fs.readFileSync(__dirname + '/config/crmConfig.json', 'utf-8'));
     const customConfig = JSON.parse(
       fs.readFileSync(__dirname + '/config/customConfig.json', 'utf-8')
@@ -41,12 +38,20 @@ async function setupApp() {
       ...appConfig,
       ...companyConfig,
       ...financeConfig,
-      ...emailTemplate,
       ...crmConfig,
       ...customConfig,
     ]);
-
     console.log('👍 Settings created : Done!');
+
+    const Email = require('../models/coreModels/Email');
+    const emailTemplate = JSON.parse(
+      fs.readFileSync(__dirname + '/config/emailTemplate.json', 'utf-8')
+    );
+
+    await Email.insertMany([
+      ...emailTemplate
+    ])
+    console.log('👍 Email Templates Created : Done!');
     console.log('🥳 Setup completed :Success!');
     process.exit();
   } catch (e) {


### PR DESCRIPTION
## Description

Provide feature of editing the email templates providing user to set subject as well as body for the template 
Major changes/addition:-

- Seperate mongodb model for email  as setting model usecase doesnt apply to it , it has additional field like subject and moreover we dont want to fetch email configurations along with all settings as it is an important aspect
- An additional key emailVariables assigned to the model , for the usecase when we need to place the variables for e.g. name as per user which can now be achieved as user will use the format {{variable}} for those cases.


## Related Issues
#548


## Screenshots (if applicable)
![ezgif com-video-to-gif (16)](https://github.com/idurar/erp-crm/assets/67551927/1036722e-d613-4225-9028-506c9f702ed9)


## Checklist

- [x] I have tested these changes
- [ ] I have updated the relevant documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the codebase
- [x] My changes generate no new warnings or errors
- [x] The title of my pull request is clear and descriptive
