### PR TITLE
fix: Able to add fields in invoices without item name idurar#207

### DIFF
--- a/frontend/src/modules/ErpPanelModule/ItemRow.jsx
+++ b/frontend/src/modules/ErpPanelModule/ItemRow.jsx
@@ -73,21 +73,21 @@ export default function ItemRow({ field, remove, offer = false, current = null }
     <Row gutter={[12, 12]} style={{ position: 'relative' }}>
       <Col className="gutter-row" span={offer ? 3 : 5}>
         <Form.Item
-  name={[field.name, 'itemName']}
-  fieldKey={[field.fieldKey, 'itemName']}
-  rules={[
-    {
-      required: true,
-      message: 'Missing itemName name',
-    },
-    {
-      pattern: /^(?!\s*$)[\s\S]+$/, // Regular expression to allow spaces, alphanumeric, and special characters, but not just spaces
-      message: 'Item Name must contain alphanumeric or special characters',
-    },
-  ]}
->
-  <Input placeholder="Item Name" />
-</Form.Item>
+          name={[field.name, 'itemName']}
+          fieldKey={[field.fieldKey, 'itemName']}
+          rules={[
+                  {
+                    required: true,
+                    message: 'Missing itemName name',
+                  },
+                  {
+                    pattern: /^(?!\s*$)[\s\S]+$/, // Regular expression to allow spaces, alphanumeric, and special characters, but not just spaces
+                    message: 'Item Name must contain alphanumeric or special characters',
+                  },
+                ]}
+        >
+          <Input placeholder="Item Name" />
+        </Form.Item>
       </Col>
       <Col className="gutter-row" span={offer ? 5 : 7}>
         <Form.Item name={[field.name, 'description']} fieldKey={[field.fieldKey, 'description']}>

--- a/frontend/src/modules/ErpPanelModule/ItemRow.jsx
+++ b/frontend/src/modules/ErpPanelModule/ItemRow.jsx
@@ -73,12 +73,21 @@ export default function ItemRow({ field, remove, offer = false, current = null }
     <Row gutter={[12, 12]} style={{ position: 'relative' }}>
       <Col className="gutter-row" span={offer ? 3 : 5}>
         <Form.Item
-          name={[field.name, 'itemName']}
-          fieldKey={[field.fieldKey, 'itemName']}
-          rules={[{ required: true, message: 'Missing itemName name' }]}
-        >
-          <Input placeholder="Item Name" />
-        </Form.Item>
+  name={[field.name, 'itemName']}
+  fieldKey={[field.fieldKey, 'itemName']}
+  rules={[
+    {
+      required: true,
+      message: 'Missing itemName name',
+    },
+    {
+      pattern: /^(?!\s*$)[\s\S]+$/, // Regular expression to allow spaces, alphanumeric, and special characters, but not just spaces
+      message: 'Item Name must contain alphanumeric or special characters',
+    },
+  ]}
+>
+  <Input placeholder="Item Name" />
+</Form.Item>
       </Col>
       <Col className="gutter-row" span={offer ? 5 : 7}>
         <Form.Item name={[field.name, 'description']} fieldKey={[field.fieldKey, 'description']}>


### PR DESCRIPTION
## Description

1. Added a pattern in rules attribute of <Form.Item> component which contain  "Item Name" input (file address : 
    frontend/src/modules/ErpPanelModule/ItemRow.jsx).
2. This pattern contains regular expression which validate that "Item Name must contain alphanumeric or special characters" in 
    real time.

## Related Issues

Able to add fields in invoices without item name https://github.com/idurar/erp-crm/issues/207

## Steps to Test

Create or edit invoice and while adding items in invoice, you can check it.

## Screenshots (if applicable)

https://ibb.co/mzM9sM7


## Checklist

- [ x ] I have tested these changes
- [ x ] I have updated the relevant documentation
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the codebase
- [ x ] My changes generate no new warnings or errors
- [ x ] The title of my pull request is clear and descriptive
